### PR TITLE
Logstash container MaxMind path and container host fix.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       - ./logstash/conf.d/:/usr/share/logstash/etc/logstash/conf.d/
       - ./logstash/conf.d/patterns/:/usr/share/logstash/etc/logstash/conf.d/patterns/
       - ./logstash/conf.d/databases/:/usr/share/logstash/etc/logstash/conf.d/databases/
-      - /usr/share/GeoIP/:/usr/share/logstash/GeoIP/
+      - /usr/share/GeoIP/:/usr/share/GeoIP/
     ports:
       - "5000:5000"
       - "9600:9600"

--- a/logstash/conf.d/50-outputs.conf
+++ b/logstash/conf.d/50-outputs.conf
@@ -3,8 +3,7 @@ output {
   ### firewall ###
   if "squid" not in [tags] and "unbound" not in [tags] and "suricata" not in [tags] and "snort" not in [tags] and "haproxy" not in [tags] and "dhcp" not in [tags] {
     elasticsearch {
-      hosts => ["http://localhost:9200"]
-      #hosts => ["http://10.0.0.20:9200"]
+      hosts => ["http://es01:9200"]
       index => "pfelk-firewall-%{+YYYY.MM}"
 #ILM#      ilm_rollover_alias => "pfelk-firewall"
 #ILM#      ilm_pattern => "000001"


### PR DESCRIPTION
# Pull Request Template

## Description

- Fix the `50-inputs` file to use the container name for the host rather than `localhost`
-- also removed a commented line from what looked like local testing
- Fix the MaxMind files path in the `docker-compose.yml` file for `logstash` container

Fixes #21 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Original Configuration
-- simply following the guide as-is produced the issue of being unable to launch logstash (the container continuously crashed). Making these two quick changes resolved the issue.
- [x] Adjusted Configuration

**Test Configuration**:
* Elastic Stack Version: 7.10.1
* Linux Version/Type: Ubuntu 20.04 fully patched
* Java Version:
* Docker Version: 20.10.2
* Docker-Compose Version: 1.25.0
* Elastic Stack Configuration Files:

## Checklist:

- [x] Code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
